### PR TITLE
Feat: Add Auto Approval if plan has no changes

### DIFF
--- a/auto-approve-if-no-changes/dev.rego
+++ b/auto-approve-if-no-changes/dev.rego
@@ -1,0 +1,17 @@
+package env0
+
+import future.keywords.if
+##
+# METADATA
+# title: Allow if no changes
+# description: Approve automatically if the plan has no changes
+
+# Allow deployment if there are no resource changes
+allow := ["No changes detected. Approval not required."] if {
+  no_changes_detected
+}
+
+# Check if all resources have only "no-op" actions
+no_changes_detected {
+  count([r | r := input.plan.resource_changes[_].change.actions[_]; r != "no-op"]) == 0
+}


### PR DESCRIPTION
This is a workaround if the user would like to force approval policy if the plan contains an indicative text. It could be used for plan with no changes or only outputs.